### PR TITLE
Remove infinite recursion

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,6 @@
 {
   inputs = {
     alejandra.url = "github:kamadorueda/alejandra";
-    alejandra.inputs.alejandra.follows = "alejandra";
     alejandra.inputs.fenix.follows = "fenix";
     alejandra.inputs.flakeCompat.follows = "flakeCompat";
     alejandra.inputs.flakeUtils.follows = "flakeUtils";


### PR DESCRIPTION
Because the repo follows itself, you get infinite recursion when updating your flake or when checking it, so you get alejandra following alejandra following alejandra, etc. This massively bloats flake.lock sizes and is just not fun to deal with.

Example:
![2022-01-31T09:41:24,612973319-05:00](https://user-images.githubusercontent.com/35778371/151813737-05c32aec-9c5e-48c6-9987-a9031a1bd5d9.png)

