### PR TITLE
feat: remove unnecesary exception

### DIFF
--- a/src/rules/key_value.rs
+++ b/src/rules/key_value.rs
@@ -88,7 +88,6 @@ pub fn rule(
                         rnix::SyntaxKind::NODE_ATTR_SET
                             | rnix::SyntaxKind::NODE_PAREN
                             | rnix::SyntaxKind::NODE_LIST
-                            | rnix::SyntaxKind::NODE_WITH
                             | rnix::SyntaxKind::NODE_STRING
                     ))
             {


### PR DESCRIPTION
- We dont care too much for the with after the apply after a key-value,
  and at the same time adding the exception can have weird
  interactions when that happens, so the less we have, the better
- 0 bytes of diff in real life: 
![image](https://user-images.githubusercontent.com/47480384/153531083-99b411f2-7c4f-4e4d-a592-7eb2ae6d8a61.png)
