### PR TITLE
feat: improve with

### DIFF
--- a/buildkite.yaml
+++ b/buildkite.yaml
@@ -46,9 +46,9 @@ steps:
       - formatting-before-vs-after.patch.txt
       - formatting-after.patch.txt
     command:
-      - git config --global user.email ci@cd
+      - git config --global user.email CI/CD
       - git config --global user.name CI/CD
-      - git clone --depth 1 https://github.com/nixos/nixpkgs
+      - git clone --branch=master --depth 1 --origin=upstream file:///data/nixpkgs
 
       - echo --- Formatting - before
       - nix run github:kamadorueda/alejandra -- nixpkgs 2>/dev/null
@@ -68,7 +68,9 @@ steps:
       - closure-after.txt
       - closure-before-vs-after.patch.txt
     command:
-      - git clone --depth 1 https://github.com/nixos/nixpkgs
+      - git config --global user.email CI/CD
+      - git config --global user.name CI/CD
+      - git clone --branch=master --depth 1 --origin=upstream file:///data/nixpkgs
 
       - echo --- Closure @ before
       - nix-env --query --available --attr-path --drv-path --file nixpkgs --xml > closure-before.txt

--- a/src/rules/key_value.rs
+++ b/src/rules/key_value.rs
@@ -52,26 +52,15 @@ pub fn rule(
             let next = children.peek_next().unwrap();
             let next_kind = next.element.kind();
 
-            if matches!(
-                next_kind,
-                rnix::SyntaxKind::NODE_ATTR_SET
-                    | rnix::SyntaxKind::NODE_PAREN
-                    | rnix::SyntaxKind::NODE_WITH
-                    | rnix::SyntaxKind::NODE_LET_IN
-                    | rnix::SyntaxKind::NODE_LIST
-                    | rnix::SyntaxKind::NODE_STRING
-            ) || (matches!(next_kind, rnix::SyntaxKind::NODE_LAMBDA)
-                && !matches!(
-                    next.element
-                        .clone()
-                        .into_node()
-                        .unwrap()
-                        .children()
-                        .next()
-                        .unwrap()
-                        .kind(),
-                    rnix::SyntaxKind::NODE_PATTERN
-                ))
+            if false
+                || matches!(
+                    next_kind,
+                    rnix::SyntaxKind::NODE_ATTR_SET
+                        | rnix::SyntaxKind::NODE_PAREN
+                        | rnix::SyntaxKind::NODE_LET_IN
+                        | rnix::SyntaxKind::NODE_LIST
+                        | rnix::SyntaxKind::NODE_STRING
+                )
                 || (matches!(next_kind, rnix::SyntaxKind::NODE_APPLY)
                     && matches!(
                         next.element
@@ -88,6 +77,39 @@ pub fn rule(
                         rnix::SyntaxKind::NODE_ATTR_SET
                             | rnix::SyntaxKind::NODE_PAREN
                             | rnix::SyntaxKind::NODE_LIST
+                            | rnix::SyntaxKind::NODE_STRING
+                    ))
+                || (matches!(next_kind, rnix::SyntaxKind::NODE_LAMBDA)
+                    && !matches!(
+                        next.element
+                            .clone()
+                            .into_node()
+                            .unwrap()
+                            .children()
+                            .next()
+                            .unwrap()
+                            .kind(),
+                        rnix::SyntaxKind::NODE_PATTERN
+                    ))
+                || (matches!(next_kind, rnix::SyntaxKind::NODE_WITH)
+                    && matches!(
+                        next.element
+                            .clone()
+                            .into_node()
+                            .unwrap()
+                            .children()
+                            .collect::<Vec<rnix::SyntaxNode>>()
+                            .iter()
+                            .rev()
+                            .next()
+                            .unwrap()
+                            .kind(),
+                        rnix::SyntaxKind::NODE_ATTR_SET
+                            | rnix::SyntaxKind::NODE_IDENT
+                            | rnix::SyntaxKind::NODE_PAREN
+                            | rnix::SyntaxKind::NODE_LET_IN
+                            | rnix::SyntaxKind::NODE_LIST
+                            | rnix::SyntaxKind::NODE_LITERAL
                             | rnix::SyntaxKind::NODE_STRING
                     ))
             {

--- a/tests/cases/with/in
+++ b/tests/cases/with/in
@@ -21,4 +21,12 @@
  (with a; with b; with c; {a=1;})
  (with a; with b; with c; {a=1;b=2;})
  (with a; /* comment */ with b; with c; {a=1;b=2;})
+  { a = with b;with b;with b;
+      1;
+      }
+    {binPath = with pkgs;
+    makeBinPath (
+       [
+         rsync
+         util-linux]);}
 ]

--- a/tests/cases/with/out
+++ b/tests/cases/with/out
@@ -46,11 +46,7 @@
     a = with b; 1;
     # comment
   }
-  (
-    with a;
-    with b;
-    with c; { a = 1; }
-  )
+  (with a; with b; with c; { a = 1; })
   (
     with a;
     with b;
@@ -70,4 +66,17 @@
       b = 2;
     }
   )
+  {
+    a = with b; with b; with b; 1;
+  }
+  {
+    binPath =
+      with pkgs;
+      makeBinPath (
+        [
+          rsync
+          util-linux
+        ]
+      );
+  }
 ]


### PR DESCRIPTION
- There were some interactions where the user would feel
  that indentation levels were missing/excessive

```diff
--- a/doc/doc-support/lib-function-docs.nix
+++ b/doc/doc-support/lib-function-docs.nix
@@ -4,7 +4,8 @@
 { pkgs ? import ./.. { }
 , locationsXml
 }:
-with pkgs; stdenv.mkDerivation {
+with pkgs;
+stdenv.mkDerivation {
   name = "nixpkgs-lib-docs";
   src = ./../../lib;
 
diff --git a/lib/generators.nix b/lib/generators.nix
index 1ec97a7f4..9cec83984 100644
--- a/lib/generators.nix
+++ b/lib/generators.nix
@@ -381,21 +381,23 @@ in
       { }:
         v: let
           isFloat = builtins.isFloat or (x: false);
-          expr = ind: x: with builtins; if x == null
-          then ""
-          else if isBool x
-          then bool ind x
-          else if isInt x
-          then int ind x
-          else if isString x
-          then str ind x
-          else if isList x
-          then list ind x
-          else if isAttrs x
-          then attrs ind x
-          else if isFloat x
-          then float ind x
-          else abort "generators.toPlist: should never happen (v = ${v})";
+          expr = ind: x:
+            with builtins;
+            if x == null
+            then ""
+            else if isBool x
+            then bool ind x
+            else if isInt x
+            then int ind x
+            else if isString x
+            then str ind x
+            else if isList x
+            then list ind x
+            else if isAttrs x
+            then attrs ind x
+            else if isFloat x
+            then float ind x
+            else abort "generators.toPlist: should never happen (v = ${v})";
 ```