### PR TITLE
fix: position update

### DIFF
--- a/src/children.rs
+++ b/src/children.rs
@@ -225,7 +225,7 @@ fn dedent_comment(pos: &crate::position::Position, text: &str) -> String {
             lines[0] = "".to_string();
         } else {
             lines.insert(0, format!("{0:<1$}", "", pos.column + 1));
-            lines[1] = format!("{0:<1$}{2}", "", pos.column + 1, lines[1]);
+            lines[1] = format!("{0:<1$}{2}", "", pos.column + 2, lines[1]);
         }
 
         // println!("{:?}", lines);

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,4 @@
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub enum Layout {
     Tall,
     Wide,

--- a/src/position.rs
+++ b/src/position.rs
@@ -17,7 +17,7 @@ impl Position {
             self.column = 0
         }
         self.column += match chars.iter().rposition(|c| *c == '\n') {
-            Some(pos) => chars.len() - pos,
+            Some(pos) => chars.len() - pos - 1,
             None => chars.len(),
         };
     }

--- a/tests/cases/root/out
+++ b/tests/cases/root/out
@@ -1,6 +1,6 @@
 /*
  Some functions f
-      name attribute.
+     name attribute.
  */
 /*
      Add to or over


### PR DESCRIPTION
```diff
diff --git a/lib/debug.nix b/lib/debug.nix
index cdec524c6..026cf99ef 100644
--- a/lib/debug.nix
+++ b/lib/debug.nix
@@ -1,17 +1,17 @@
 /*
  Collection of functions useful for debugging
-  broken nix expressions.
+ broken nix expressions.
  
-  * `trace`-like functions take two values, print
-    the first to stderr and return the second.
-  * `traceVal`-like functions take one argument
-    which both printed and returned.
-  * `traceSeq`-like functions fully evaluate their
-    traced value before printing (not just to â€œweak
-    head normal formâ€ like trace does by default).
-  * Functions that end in `-Fn` take an additional
-    function as their first argument, which is applied
-    to the traced value before it is printed.
+ * `trace`-like functions take two values, print
+   the first to stderr and return the second.
+ * `traceVal`-like functions take one argument
+   which both printed and returned.
+ * `traceSeq`-like functions fully evaluate their
+   traced value before printing (not just to â€œweak
+   head normal formâ€ like trace does by default).
+ * Functions that end in `-Fn` take an additional
+   function as their first argument, which is applied
+   to the traced value before it is printed.
  */
 { lib }:
 let
diff --git a/lib/default.nix b/lib/default.nix
index 3d07a869a..46dce6d77 100644
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -1,5 +1,5 @@
 /*
-  Library of low-level helper functions for nix expressions.
+   Library of low-level helper functions for nix expressions.
  *
  * Please implement (mostly) exhaustive unit tests
  * for new functions in `./tests.nix'.
diff --git a/lib/generators.nix b/lib/generators.nix
index 5d92ca1b5..315ee2680 100644
--- a/lib/generators.nix
+++ b/lib/generators.nix
@@ -1,5 +1,5 @@
 /*
-  Functions that generate widespread file
+   Functions that generate widespread file
  * formats from nix data structures.
  *
  * They all follow a similar interface:
diff --git a/lib/meta.nix b/lib/meta.nix
index cc36cb2c5..607f0e6d0 100644
--- a/lib/meta.nix
+++ b/lib/meta.nix
@@ -1,6 +1,6 @@
 /*
  Some functions for manipulating meta attributes, as well as the
-  name attribute.
+ name attribute.
  */
 { lib }:
 rec {
diff --git a/lib/zip-int-bits.nix b/lib/zip-int-bits.nix
index 922b29840..834e65b8d 100644
--- a/lib/zip-int-bits.nix
+++ b/lib/zip-int-bits.nix
@@ -1,7 +1,7 @@
 /*
  Helper function to implement a fallback for the bit operators
-  `bitAnd`, `bitOr` and `bitXOr` on older nix version.
-  See ./trivial.nix
+ `bitAnd`, `bitOr` and `bitXOr` on older nix version.
+ See ./trivial.nix
  */
 f: x: y: let
   # (intToBits 6) -> [ 0 1 1 ]
diff --git a/maintainers/maintainer-list.nix b/maintainers/maintainer-list.nix
index bfd762735..808b5ad31 100644
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1,54 +1,54 @@
 /*
  List of NixOS maintainers.
-   ```nix
-   handle = {
-     # Required
-     name = "Your name";
-     email = "address@example.org";
+  ```nix
+  handle = {
+    # Required
+    name = "Your name";
+    email = "address@example.org";
  
-     # Optional
-     matrix = "@user:example.org";
-     github = "GithubUsername";
-     githubId = your-github-id;
-     keys = [{
-       longkeyid = "rsa2048/0x0123456789ABCDEF";
-       fingerprint = "AAAA BBBB CCCC DDDD EEEE  FFFF 0000 1111 2222 3333";
-     }];
-   };
-   ```
+    # Optional
+    matrix = "@user:example.org";
+    github = "GithubUsername";
+    githubId = your-github-id;
+    keys = [{
+      longkeyid = "rsa2048/0x0123456789ABCDEF";
+      fingerprint = "AAAA BBBB CCCC DDDD EEEE  FFFF 0000 1111 2222 3333";
+    }];
+  };
+  ```
  
-   where
+  where
  
-   - `handle` is the handle you are going to use in nixpkgs expressions,
-   - `name` is your, preferably real, name,
-   - `email` is your maintainer email address,
-   - `matrix` is your Matrix user ID,
-   - `github` is your GitHub handle (as it appears in the URL of your profile page, `https://github.com/<userhandle>`),
-   - `githubId` is your GitHub user ID, which can be found at `https://api.github.com/users/<userhandle>`,
-   - `keys` is a list of your PGP/GPG key IDs and fingerprints.
+  - `handle` is the handle you are going to use in nixpkgs expressions,
+  - `name` is your, preferably real, name,
+  - `email` is your maintainer email address,
+  - `matrix` is your Matrix user ID,
+  - `github` is your GitHub handle (as it appears in the URL of your profile page, `https://github.com/<userhandle>`),
+  - `githubId` is your GitHub user ID, which can be found at `https://api.github.com/users/<userhandle>`,
+  - `keys` is a list of your PGP/GPG key IDs and fingerprints.
  
-   `handle == github` is strongly preferred whenever `github` is an acceptable attribute name and is short and convenient.
+  `handle == github` is strongly preferred whenever `github` is an acceptable attribute name and is short and convenient.
  
-   If `github` begins with a numeral, `handle` should be prefixed with an underscore.
-   ```nix
-   _1example = {
-     github = "1example";
-   };
-   ```
+  If `github` begins with a numeral, `handle` should be prefixed with an underscore.
+  ```nix
+  _1example = {
+    github = "1example";
+  };
+  ```
  
-   Add PGP/GPG keys only if you actually use them to sign commits and/or mail.
+  Add PGP/GPG keys only if you actually use them to sign commits and/or mail.
  
-   To get the required PGP/GPG values for a key run
-   ```shell
-   gpg --keyid-format 0xlong --fingerprint <email> | head -n 2
-   ```
+  To get the required PGP/GPG values for a key run
+  ```shell
+  gpg --keyid-format 0xlong --fingerprint <email> | head -n 2
+  ```
  
-   !!! Note that PGP/GPG values stored here are for informational purposes only, don't use this file as a source of truth.
+  !!! Note that PGP/GPG values stored here are for informational purposes only, don't use this file as a source of truth.
  
-   More fields may be added in the future, however, in order to comply with GDPR this file should stay as minimal as possible.
+  More fields may be added in the future, however, in order to comply with GDPR this file should stay as minimal as possible.
  
-   Please keep the list alphabetically sorted.
-   See `./scripts/check-maintainer-github-handles.sh` for an example on how to work with this data.
+  Please keep the list alphabetically sorted.
+  See `./scripts/check-maintainer-github-handles.sh` for an example on how to work with this data.
  */
 {
   _0qq = {
diff --git a/maintainers/scripts/all-tarballs.nix b/maintainers/scripts/all-tarballs.nix
index 1433a5bde..57f324ab4 100644
--- a/maintainers/scripts/all-tarballs.nix
+++ b/maintainers/scripts/all-tarballs.nix
@@ -1,10 +1,10 @@
 /*
  Helper expression for copy-tarballs. This returns (nearly) all
-  tarballs used the free packages in Nixpkgs.
+ tarballs used the free packages in Nixpkgs.
  
-  Typical usage:
+ Typical usage:
  
-  $ copy-tarballs.pl --expr 'import <nixpkgs/maintainers/scripts/all-tarballs.nix>'
+ $ copy-tarballs.pl --expr 'import <nixpkgs/maintainers/scripts/all-tarballs.nix>'
  */
 import ../../pkgs/top-level/release.nix
 {
diff --git a/maintainers/scripts/haskell/test-configurations.nix b/maintainers/scripts/haskell/test-configurations.nix
index f09e5057f..d20766595 100644
--- a/maintainers/scripts/haskell/test-configurations.nix
+++ b/maintainers/scripts/haskell/test-configurations.nix
@@ -1,50 +1,50 @@
 /*
  Nix expression to test for regressions in the Haskell configuration overlays.
  
-  test-configurations.nix determines all attributes touched by given Haskell
-  configuration overlays (i. e. pkgs/development/haskell-modules/configuration-*.nix)
-  and builds all derivations (or at least a reasonable subset) affected by
-  these overrides.
+ test-configurations.nix determines all attributes touched by given Haskell
+ configuration overlays (i. e. pkgs/development/haskell-modules/configuration-*.nix)
+ and builds all derivations (or at least a reasonable subset) affected by
+ these overrides.
  
-  By default, it checks `configuration-{common,nix,ghc-8.10.x}.nix`. You can
-  invoke it like this:
+ By default, it checks `configuration-{common,nix,ghc-8.10.x}.nix`. You can
+ invoke it like this:
  
-    nix-build maintainers/scripts/haskell/test-configurations.nix --keep-going
+   nix-build maintainers/scripts/haskell/test-configurations.nix --keep-going
  
-  It is possible to specify other configurations:
+ It is possible to specify other configurations:
  
-    nix-build maintainers/scripts/haskell/test-configurations.nix \
-      --arg files '[ "configuration-ghc-9.0.x.nix" "configuration-ghc-9.2.x.nix" ]' \
-      --keep-going
+   nix-build maintainers/scripts/haskell/test-configurations.nix \
+     --arg files '[ "configuration-ghc-9.0.x.nix" "configuration-ghc-9.2.x.nix" ]' \
+     --keep-going
  
-  You can also just supply a single string:
+ You can also just supply a single string:
  
-    nix-build maintainers/scripts/haskell/test-configurations.nix \
-      --argstr files "configuration-arm.nix" --keep-going
+   nix-build maintainers/scripts/haskell/test-configurations.nix \
+     --argstr files "configuration-arm.nix" --keep-going
  
-  You can even supply full paths which is handy, as it allows for tab-completing
-  the configurations:
+ You can even supply full paths which is handy, as it allows for tab-completing
+ the configurations:
  
-    nix-build maintainers/scripts/haskell/test-configurations.nix \
-      --argstr files pkgs/development/haskell-modules/configuration-arm.nix \
-      --keep-going
+   nix-build maintainers/scripts/haskell/test-configurations.nix \
+     --argstr files pkgs/development/haskell-modules/configuration-arm.nix \
+     --keep-going
  
-  By default, derivation that fail to evaluate are skipped, unless they are
-  â€œjustâ€ marked as broken. You can check for other eval errors like this:
+ By default, derivation that fail to evaluate are skipped, unless they are
+ â€œjustâ€ marked as broken. You can check for other eval errors like this:
  
-    nix-build maintainers/scripts/haskell/test-configurations.nix \
-      --arg skipEvalErrors false --keep-going
+   nix-build maintainers/scripts/haskell/test-configurations.nix \
+     --arg skipEvalErrors false --keep-going
  
-  You can also disable checking broken packages by passing a nixpkgs config:
+ You can also disable checking broken packages by passing a nixpkgs config:
  
-    nix-build maintainers/scripts/haskell/test-configurations.nix \
-      --arg config '{ allowBroken = false; }' --keep-going
+   nix-build maintainers/scripts/haskell/test-configurations.nix \
+     --arg config '{ allowBroken = false; }' --keep-going
  
-  By default the haskell.packages.ghc*Binary sets used for bootstrapping GHC
-  are _not_ tested. You can change this using:
+ By default the haskell.packages.ghc*Binary sets used for bootstrapping GHC
+ are _not_ tested. You can change this using:
  
-    nix-build maintainers/scripts/haskell/test-configurations.nix \
-      --arg skipBinaryGHCs false --keep-going
+   nix-build maintainers/scripts/haskell/test-configurations.nix \
+     --arg skipBinaryGHCs false --keep-going
  */
 {
   files ?
diff --git a/maintainers/team-list.nix b/maintainers/team-list.nix
index ca9e7caa9..e41805a93 100644
--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -1,5 +1,5 @@
 /*
- List of maintainer teams.
+  List of maintainer teams.
    name = {
      # Required
      members = [ maintainer1 maintainer2 ];
diff --git a/nixos/lib/make-channel.nix b/nixos/lib/make-channel.nix
index 669c90fda..1c3a77fe0 100644
--- a/nixos/lib/make-channel.nix
+++ b/nixos/lib/make-channel.nix
@@ -1,5 +1,5 @@
 /*
-  Build a channel tarball. These contain, in addition to the nixpkgs
+   Build a channel tarball. These contain, in addition to the nixpkgs
  * expressions themselves, files that indicate the version of nixpkgs
  * that they represent.
  */
diff --git a/nixos/lib/make-options-doc/default.nix b/nixos/lib/make-options-doc/default.nix
index 396f4dc69..e072c5c13 100644
--- a/nixos/lib/make-options-doc/default.nix
+++ b/nixos/lib/make-options-doc/default.nix
@@ -1,20 +1,20 @@
 /*
  Generate JSON, XML and DocBook documentation for given NixOS options.
  
-  Minimal example:
+ Minimal example:
  
-   { pkgs,  }:
+  { pkgs,  }:
  
-   let
-     eval = import (pkgs.path + "/nixos/lib/eval-config.nix") {
-       baseModules = [
-         ../module.nix
-       ];
-       modules = [];
-     };
-   in pkgs.nixosOptionsDoc {
-     options = eval.options;
-   }
+  let
+    eval = import (pkgs.path + "/nixos/lib/eval-config.nix") {
+      baseModules = [
+        ../module.nix
+      ];
+      modules = [];
+    };
+  in pkgs.nixosOptionsDoc {
+    options = eval.options;
+  }
  */
 {
   pkgs,
```