### PR TITLE
feat: nicer string interpolation

### DIFF
--- a/src/rules/string.rs
+++ b/src/rules/string.rs
@@ -141,9 +141,11 @@ pub fn rule(
                     ));
 
                     if index + 1 != portions.len() {
+                        steps.push_back(crate::builder::Step::Indent);
                         steps.push_back(crate::builder::Step::FormatWider(
                             interpolations.next().unwrap().clone(),
                         ));
+                        steps.push_back(crate::builder::Step::Dedent);
                     }
                 }
             }

--- a/tests/cases/string/in
+++ b/tests/cases/string/in
@@ -78,4 +78,14 @@
         <plist version="1.0">
         ${ expr "" v }
         </plist>''
+
+  ''
+    --${
+    "test"
+  }
+  ''
+
+  "--${
+    "test"
+  }"
 ]

--- a/tests/cases/string/out
+++ b/tests/cases/string/out
@@ -78,4 +78,14 @@
     <plist version="1.0">
     ${expr "" v}
     </plist>''
+
+  ''
+    --${
+      "test"
+    }
+  ''
+
+  "--${
+    "test"
+  }"
 ]


### PR DESCRIPTION
```diff
diff --git a/nixos/doc/manual/default.nix b/nixos/doc/manual/default.nix
index 83abb46d0..82b6e89fc 100644
--- a/nixos/doc/manual/default.nix
+++ b/nixos/doc/manual/default.nix
@@ -36,14 +36,14 @@ with pkgs; let
   modulesDoc = builtins.toFile "modules.xml" ''
     <section xmlns:xi="http://www.w3.org/2001/XInclude" id="modules">
     ${
-    (
-      lib.concatMapStrings (
-        path: ''
-          <xi:include href="${path}" />
-        ''
-      ) (lib.catAttrs "value" config.meta.doc)
-    )
-  }
+      (
+        lib.concatMapStrings (
+          path: ''
+            <xi:include href="${path}" />
+          ''
+        ) (lib.catAttrs "value" config.meta.doc)
+      )
+    }
     </section>
   '';
 
diff --git a/nixos/lib/make-disk-image.nix b/nixos/lib/make-disk-image.nix
index 7349d1c35..5323f7529 100644
--- a/nixos/lib/make-disk-image.nix
+++ b/nixos/lib/make-disk-image.nix
@@ -285,107 +285,107 @@ in let
     nixos-install --root $root --no-bootloader --no-root-passwd \
       --system ${config.system.build.toplevel} \
       ${
-    if copyChannel
-    then "--channel ${channelSources}"
-    else "--no-channel-copy"
-  } \
+      if copyChannel
+      then "--channel ${channelSources}"
+      else "--no-channel-copy"
+    } \
       --substituters ""
 
     ${
-    optionalString (additionalPaths' != []) ''
-      nix --extra-experimental-features nix-command copy --to $root --no-check-sigs ${concatStringsSep " " additionalPaths'}
-    ''
-  }
+      optionalString (additionalPaths' != []) ''
+        nix --extra-experimental-features nix-command copy --to $root --no-check-sigs ${concatStringsSep " " additionalPaths'}
+      ''
+    }
 
     diskImage=nixos.raw
 
     ${
-    if diskSize == "auto"
-    then
-      ''
-        ${
-        if partitionTableType == "efi" || partitionTableType == "hybrid"
-        then
-          ''
-            # Add the GPT at the end
-            gptSpace=$(( 512 * 34 * 1 ))
-            # Normally we'd need to account for alignment and things, if bootSize
-            # represented the actual size of the boot partition. But it instead
-            # represents the offset at which it ends.
-            # So we know bootSize is the reserved space in front of the partition.
-            reservedSpace=$(( gptSpace + $(numfmt --from=iec '${bootSize}') ))
-          ''
-        else if partitionTableType == "legacy+gpt"
-        then
-          ''
-            # Add the GPT at the end
-            gptSpace=$(( 512 * 34 * 1 ))
-            # And include the bios_grub partition; the ext4 partition starts at 2MB exactly.
-            reservedSpace=$(( gptSpace + 2 * mebibyte ))
-          ''
-        else if partitionTableType == "legacy"
-        then
-          ''
-            # Add the 1MiB aligned reserved space (includes MBR)
-            reservedSpace=$(( mebibyte ))
-          ''
-        else
-          ''
-            reservedSpace=0
-          ''
-      }
-        additionalSpace=$(( $(numfmt --from=iec '${additionalSpace}') + reservedSpace ))
-
-        # Compute required space in filesystem blocks
-        diskUsage=$(find . ! -type d -print0 | du --files0-from=- --apparent-size --block-size "${blockSize}" | cut -f1 | sum_lines)
-        # Each inode takes space!
-        numInodes=$(find . | wc -l)
-        # Convert to bytes, inodes take two blocks each!
-        diskUsage=$(( (diskUsage + 2 * numInodes) * ${blockSize} ))
-        # Then increase the required space to account for the reserved blocks.
-        fudge=$(compute_fudge $diskUsage)
-        requiredFilesystemSpace=$(( diskUsage + fudge ))
-
-        diskSize=$(( requiredFilesystemSpace  + additionalSpace ))
-
-        # Round up to the nearest mebibyte.
-        # This ensures whole 512 bytes sector sizes in the disk image
-        # and helps towards aligning partitions optimally.
-        if (( diskSize % mebibyte )); then
-          diskSize=$(( ( diskSize / mebibyte + 1) * mebibyte ))
-        fi
-
-        truncate -s "$diskSize" $diskImage
-
-        printf "Automatic disk size...\n"
-        printf "  Closure space use: %d bytes\n" $diskUsage
-        printf "  fudge: %d bytes\n" $fudge
-        printf "  Filesystem size needed: %d bytes\n" $requiredFilesystemSpace
-        printf "  Additional space: %d bytes\n" $additionalSpace
-        printf "  Disk image size: %d bytes\n" $diskSize
-      ''
-    else
-      ''
-        truncate -s ${toString diskSize}M $diskImage
-      ''
-  }
+      if diskSize == "auto"
+      then
+        ''
+          ${
+            if partitionTableType == "efi" || partitionTableType == "hybrid"
+            then
+              ''
+                # Add the GPT at the end
+                gptSpace=$(( 512 * 34 * 1 ))
+                # Normally we'd need to account for alignment and things, if bootSize
+                # represented the actual size of the boot partition. But it instead
+                # represents the offset at which it ends.
+                # So we know bootSize is the reserved space in front of the partition.
+                reservedSpace=$(( gptSpace + $(numfmt --from=iec '${bootSize}') ))
+              ''
+            else if partitionTableType == "legacy+gpt"
+            then
+              ''
+                # Add the GPT at the end
+                gptSpace=$(( 512 * 34 * 1 ))
+                # And include the bios_grub partition; the ext4 partition starts at 2MB exactly.
+                reservedSpace=$(( gptSpace + 2 * mebibyte ))
+              ''
+            else if partitionTableType == "legacy"
+            then
+              ''
+                # Add the 1MiB aligned reserved space (includes MBR)
+                reservedSpace=$(( mebibyte ))
+              ''
+            else
+              ''
+                reservedSpace=0
+              ''
+          }
+          additionalSpace=$(( $(numfmt --from=iec '${additionalSpace}') + reservedSpace ))
+
+          # Compute required space in filesystem blocks
+          diskUsage=$(find . ! -type d -print0 | du --files0-from=- --apparent-size --block-size "${blockSize}" | cut -f1 | sum_lines)
+          # Each inode takes space!
+          numInodes=$(find . | wc -l)
+          # Convert to bytes, inodes take two blocks each!
+          diskUsage=$(( (diskUsage + 2 * numInodes) * ${blockSize} ))
+          # Then increase the required space to account for the reserved blocks.
+          fudge=$(compute_fudge $diskUsage)
+          requiredFilesystemSpace=$(( diskUsage + fudge ))
+
+          diskSize=$(( requiredFilesystemSpace  + additionalSpace ))
+
+          # Round up to the nearest mebibyte.
+          # This ensures whole 512 bytes sector sizes in the disk image
+          # and helps towards aligning partitions optimally.
+          if (( diskSize % mebibyte )); then
+            diskSize=$(( ( diskSize / mebibyte + 1) * mebibyte ))
+          fi
+
+          truncate -s "$diskSize" $diskImage
+
+          printf "Automatic disk size...\n"
+          printf "  Closure space use: %d bytes\n" $diskUsage
+          printf "  fudge: %d bytes\n" $fudge
+          printf "  Filesystem size needed: %d bytes\n" $requiredFilesystemSpace
+          printf "  Additional space: %d bytes\n" $additionalSpace
+          printf "  Disk image size: %d bytes\n" $diskSize
+        ''
+      else
+        ''
+          truncate -s ${toString diskSize}M $diskImage
+        ''
+    }
 
     ${partitionDiskScript}
 
     ${
-    if partitionTableType != "none"
-    then
-      ''
-        # Get start & length of the root partition in sectors to $START and $SECTORS.
-        eval $(partx $diskImage -o START,SECTORS --nr ${rootPartition} --pairs)
+      if partitionTableType != "none"
+      then
+        ''
+          # Get start & length of the root partition in sectors to $START and $SECTORS.
+          eval $(partx $diskImage -o START,SECTORS --nr ${rootPartition} --pairs)
 
-        mkfs.${fsType} -b ${blockSize} -F -L ${label} $diskImage -E offset=$(sectorsToBytes $START) $(sectorsToKilobytes $SECTORS)K
-      ''
-    else
-      ''
-        mkfs.${fsType} -b ${blockSize} -F -L ${label} $diskImage
-      ''
-  }
+          mkfs.${fsType} -b ${blockSize} -F -L ${label} $diskImage -E offset=$(sectorsToBytes $START) $(sectorsToKilobytes $SECTORS)K
+        ''
+      else
+        ''
+          mkfs.${fsType} -b ${blockSize} -F -L ${label} $diskImage
+        ''
+    }
 
     echo "copying staging root to image..."
     cptofs -p ${optionalString (partitionTableType != "none") "-P ${rootPartition}"} \
@@ -397,16 +397,16 @@ in let
 
   moveOrConvertImage = ''
     ${
-    if format == "raw"
-    then
-      ''
-        mv $diskImage $out/${filename}
-      ''
-    else
-      ''
-        ${pkgs.qemu}/bin/qemu-img convert -f raw -O ${format} ${compress} $diskImage $out/${filename}
-      ''
-  }
+      if format == "raw"
+      then
+        ''
+          mv $diskImage $out/${filename}
+        ''
+      else
+        ''
+          ${pkgs.qemu}/bin/qemu-img convert -f raw -O ${format} ${compress} $diskImage $out/${filename}
+        ''
+    }
     diskImage=$out/${filename}
   '';
 
@@ -420,10 +420,10 @@ in let
       export PATH=${binPath}:$PATH
 
       rootDisk=${
-      if partitionTableType != "none"
-      then "/dev/vda${rootPartition}"
-      else "/dev/vda"
-    }
+        if partitionTableType != "none"
+        then "/dev/vda${rootPartition}"
+        else "/dev/vda"
+      }
 
       # Some tools assume these exist
       ln -s vda /dev/xvda
@@ -439,30 +439,30 @@ in let
       # Create the ESP and mount it. Unlike e2fsprogs, mkfs.vfat doesn't support an
       # '-E offset=X' option, so we can't do this outside the VM.
       ${
-      optionalString (partitionTableType == "efi" || partitionTableType == "hybrid") ''
-        mkdir -p /mnt/boot
-        mkfs.vfat -n ESP /dev/vda1
-        mount /dev/vda1 /mnt/boot
-      ''
-    }
+        optionalString (partitionTableType == "efi" || partitionTableType == "hybrid") ''
+          mkdir -p /mnt/boot
+          mkfs.vfat -n ESP /dev/vda1
+          mount /dev/vda1 /mnt/boot
+        ''
+      }
 
       # Install a configuration.nix
       mkdir -p /mnt/etc/nixos
       ${
-      optionalString (configFile != null) ''
-        cp ${configFile} /mnt/etc/nixos/configuration.nix
-      ''
-    }
+        optionalString (configFile != null) ''
+          cp ${configFile} /mnt/etc/nixos/configuration.nix
+        ''
+      }
 
       ${
-      lib.optionalString installBootLoader ''
-        # Set up core system link, GRUB, etc.
-        NIXOS_INSTALL_BOOTLOADER=1 nixos-enter --root $mountPoint -- /nix/var/nix/profiles/system/bin/switch-to-configuration boot
+        lib.optionalString installBootLoader ''
+          # Set up core system link, GRUB, etc.
+          NIXOS_INSTALL_BOOTLOADER=1 nixos-enter --root $mountPoint -- /nix/var/nix/profiles/system/bin/switch-to-configuration boot
 
-        # The above scripts will generate a random machine-id and we don't want to bake a single ID into all our images
-        rm -f $mountPoint/etc/machine-id
-      ''
-    }
+          # The above scripts will generate a random machine-id and we don't want to bake a single ID into all our images
+          rm -f $mountPoint/etc/machine-id
+        ''
+      }
 
       # Set the ownerships of the contents. The modes are set in preVM.
       # No globbing on targets, so no need to set -f
@@ -485,10 +485,10 @@ in let
       # mount, so the `-c 0` and `-i 0` don't affect it. Setting it to `now` doesn't produce deterministic
       # output, of course, but we can fix that when/if we start making images deterministic.
       ${
-      optionalString (fsType == "ext4") ''
-        tune2fs -T now -c 0 -i 0 $rootDisk
-      ''
-    }
+        optionalString (fsType == "ext4") ''
+          tune2fs -T now -c 0 -i 0 $rootDisk
+        ''
+      }
     ''
   );
 in
```