### PR TITLE
Ignore the generated list of nixpkgs files for language stats

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Ignore the generated list of nixpkgs files for language stats.
+nixpkgsFiles.js linguist-generated


### PR DESCRIPTION
This is totally another nitpick, but it bothered me that Github lists this repository as almost entirely being Javascript :)

Before this commit:
![screenshot before](https://user-images.githubusercontent.com/1552853/154800124-3d310ff4-6bd7-49a6-98f3-8736f24e8ff2.png)

After this commit:
![screenshot after](https://user-images.githubusercontent.com/1552853/154800097-0ff8e238-a573-4608-997e-7104ed35b58f.png)
