### PR TITLE
feat: only cross compile static binaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,13 +101,17 @@ Please visit:
 
 ### Prebuilt binaries
 
-You can download a binary for your platform
-from the
-[releases section](https://github.com/kamadorueda/alejandra/releases/),
-make it executable
+You can download a binary for your platform,
+make it executable (`$ chmod +x`)
 and have fun!
 
-Alternatively there is an automated method.
+- [aarch64-unknown-linux-musl](https://github.com/kamadorueda/alejandra/releases/download/0.3.0/alejandra-aarch64-unknown-linux-musl)
+- [armv6l-unknown-linux-musleabihf](https://github.com/kamadorueda/alejandra/releases/download/0.3.0/alejandra-armv6l-unknown-linux-musleabihf)
+- [armv7l-unknown-linux-musleabihf](https://github.com/kamadorueda/alejandra/releases/download/0.3.0/alejandra-armv7l-unknown-linux-musleabihf)
+- [i686-unknown-linux-musl](https://github.com/kamadorueda/alejandra/releases/download/0.3.0/alejandra-i686-unknown-linux-musl)
+- [x86_64-unknown-linux-musl](https://github.com/kamadorueda/alejandra/releases/download/0.3.0/alejandra-x86_64-unknown-linux-musl)
+
+Alternatively there is an automated method for some platforms.
 It needs:
 [curl](https://curl.se/),
 [sh](https://www.gnu.org/software/bash/) and

--- a/flake.nix
+++ b/flake.nix
@@ -133,16 +133,12 @@
           alejandra
           pkgsStatic.alejandra
 
-          pkgsCross.aarch64-multiplatform.alejandra
           pkgsCross.aarch64-multiplatform.pkgsStatic.alejandra
 
-          pkgsCross.armv7l-hf-multiplatform.alejandra
           pkgsCross.armv7l-hf-multiplatform.pkgsStatic.alejandra
 
-          pkgsCross.gnu32.alejandra
           pkgsCross.gnu32.pkgsStatic.alejandra
 
-          pkgsCross.raspberryPi.alejandra
           pkgsCross.raspberryPi.pkgsStatic.alejandra
         ]
       )

--- a/integrations/vscode/yarn.lock.nix
+++ b/integrations/vscode/yarn.lock.nix
@@ -4,8 +4,7 @@
   linkFarm,
   runCommand,
   gnutar,
-}:
-rec {
+}: rec {
   offline_cache = linkFarm "offline" packages;
   packages = [
     {


### PR DESCRIPTION
- Users downloading the pre-built binaries are
  not copying the closure for gnu/gcc, so
  only the static binary would work