### PR TITLE
perf: enable lto

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,2 +1,5 @@
+[profile.release]
+lto = true
+
 [workspace]
 members = ["src/*"]

--- a/README.md
+++ b/README.md
@@ -215,11 +215,11 @@ Please see: [CHANGELOG.md](./CHANGELOG.md).
 
     | Logical Cores | Seconds |
     | :-----------: | :-----: |
-    |       1       |   45    |
-    |       2       |   22    |
-    |       4       |   14    |
+    |       1       |   35    |
+    |       2       |   18    |
+    |       4       |   10    |
     |       8       |   10    |
-    |      16       |   11    |
+    |      16       |   10    |
 
 [^semantic-changes]: The methodology to claim this is:
 


### PR DESCRIPTION
- This cuts the binary size by 40%, and makes runtime 2 seconds faster