### PR TITLE
Supply an i686-linux package

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -88,7 +88,7 @@
 
     defaultPackage."aarch64-darwin" = packages."aarch64-darwin"."alejandra-aarch64-apple-darwin";
     defaultPackage."aarch64-linux" = packages."aarch64-linux"."alejandra-aarch64-unknown-linux-gnu";
-    defaultPackage."i686-linux" = packages."aarch64-linux"."alejandra-i686-unknown-linux-gnu";
+    defaultPackage."i686-linux" = packages."i686-linux"."alejandra-i686-unknown-linux-gnu";
     defaultPackage."x86_64-darwin" = packages."x86_64-darwin"."alejandra-x86_64-apple-darwin";
     defaultPackage."x86_64-linux" = packages."x86_64-linux"."alejandra-x86_64-unknown-linux-gnu";
 

--- a/flake.nix
+++ b/flake.nix
@@ -55,6 +55,7 @@
 
     nixpkgs."aarch64-darwin" = nixpkgsForHost "aarch64-darwin";
     nixpkgs."aarch64-linux" = nixpkgsForHost "aarch64-linux";
+    nixpkgs."i686-linux" = nixpkgsForHost "i686-linux";
     nixpkgs."x86_64-darwin" = nixpkgsForHost "x86_64-darwin";
     nixpkgs."x86_64-linux" = nixpkgsForHost "x86_64-linux";
 
@@ -81,11 +82,13 @@
   in rec {
     checks."aarch64-darwin" = packages."aarch64-darwin";
     checks."aarch64-linux" = packages."aarch64-linux";
+    checks."i686-linux" = packages."i686-linux";
     checks."x86_64-darwin" = packages."x86_64-darwin";
     checks."x86_64-linux" = packages."x86_64-linux";
 
     defaultPackage."aarch64-darwin" = packages."aarch64-darwin"."alejandra-aarch64-apple-darwin";
     defaultPackage."aarch64-linux" = packages."aarch64-linux"."alejandra-aarch64-unknown-linux-gnu";
+    defaultPackage."i686-linux" = packages."aarch64-linux"."alejandra-i686-unknown-linux-gnu";
     defaultPackage."x86_64-darwin" = packages."x86_64-darwin"."alejandra-x86_64-apple-darwin";
     defaultPackage."x86_64-linux" = packages."x86_64-linux"."alejandra-x86_64-unknown-linux-gnu";
 
@@ -119,6 +122,10 @@
       buildBinariesForHost "aarch64-linux" [
         alejandra
         pkgsStatic.alejandra
+      ];
+    packages."i686-linux" = with nixpkgs."i686-linux";
+      buildBinariesForHost "i686-linux" [
+        alejandra
       ];
     packages."x86_64-darwin" = with nixpkgs."x86_64-darwin";
       buildBinariesForHost "x86_64-darwin" [


### PR DESCRIPTION
(This is completely untested at the moment but I felt it's probably easy to quickly guess what the fix is rather than open issue. Please check before merging!)

Many people are currently using `defaultSystems` (or `flake-utils.lib.eachDefaultSystem` as suggested in the nixos wiki) which [includes i686-linux](https://github.com/numtide/flake-utils/blob/3cecb5b042f7f209c56ffd8371b2711a290ec797/default.nix#L3-L9).
