### PR TITLE
fix: respect - for stdin

### DIFF
--- a/src/alejandra_cli/src/cli.rs
+++ b/src/alejandra_cli/src/cli.rs
@@ -10,7 +10,7 @@ pub(crate) fn parse(args: Vec<String>) -> clap::ArgMatches {
         .version(alejandra_engine::version::VERSION)
         .arg(
             clap::Arg::new("include")
-                .help("Files or directories, or none to format stdin.")
+                .help("Files or directories, or none (or '-') to format stdin.")
                 .multiple_values(true),
         )
         .arg(
@@ -390,11 +390,15 @@ pub fn main() -> std::io::Result<()> {
 
     let formatted_paths = match matches.values_of("include") {
         Some(include) => {
-            let include = include.collect();
+            let include : Vec<_> = include.collect();
             let exclude = match matches.values_of("exclude") {
                 Some(exclude) => exclude.collect(),
                 None => vec![],
             };
+
+            if include.len() == 1 && exclude.len() == 0 && include[0] == "-" {
+                vec![crate::cli::stdin(quiet)];
+            }
 
             let paths: Vec<String> = crate::find::nix_files(include, exclude);
 

--- a/src/alejandra_cli/src/cli.rs
+++ b/src/alejandra_cli/src/cli.rs
@@ -10,7 +10,7 @@ pub(crate) fn parse(args: Vec<String>) -> clap::ArgMatches {
         .version(alejandra_engine::version::VERSION)
         .arg(
             clap::Arg::new("include")
-                .help("Files or directories, or none (or '-') to format stdin.")
+                .help("Files or directories, or none (or a single '-') to format stdin.")
                 .multiple_values(true),
         )
         .arg(


### PR DESCRIPTION
It's kind of an ugly fix, but has a special case allowing a "-" to represent stdin if it is the only include/exclude path provided. Starts to follow the [POSIX](https://pubs.opengroup.org/onlinepubs/009695399/basedefs/xbd_chap12.html#tag_12_02) guidance.

Thought about adding "is_stdin" to find.rs, but that also ends up confusing things.