### PR TITLE
feat: add pre-commit hook (without altering repo structure)

### DIFF
--- a/.pre-commit-entry.sh
+++ b/.pre-commit-entry.sh
@@ -1,0 +1,3 @@
+#! /usr/bin/env sh
+
+nix run github:kamadorueda/alejandra -- -q "$@"

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,7 @@
+- id: alejandra
+  name: alejandra
+  description: Format Nix code with Alejandra.
+  entry: .pre-commit-entry.sh
+  language: script
+  files: \.nix$
+  minimum_pre_commit_version: 1.18.1


### PR DESCRIPTION
Following #275, this add a [`pre-commit`](https://pre-commit.com) hook so that Alejandra can be added to any project as a pre-commit hook in `.pre-commit-hooks.yaml`. Unlike my previous PR, this does not require altering the repository structure.

The hook does not require Cargo to be installed, Alejandra will be installed and ran via `nix run github:kamadorueda/alejandra`.

The hook can be tested with:

```shell
pre-commit try-repo ./ --verbose
```