### PR TITLE
feat: add system pre-commit hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,7 +1,15 @@
 - id: alejandra
-  name: alejandra
+  name: alejandra (Nix)
   description: Format Nix code with Alejandra.
   entry: .pre-commit-entry.sh
   language: script
   files: \.nix$
   minimum_pre_commit_version: 1.18.1
+
+- id: alejandra-system
+  name: alejandra (system)
+  description: Format Nix code with Alejandra.
+  entry: alejandra
+  language: system
+  files: \.nix$
+  args: ["-q"]


### PR DESCRIPTION
After seeing the [StyLua's `pre-commit-hooks.yaml`](https://github.com/JohnnyMorganz/StyLua/blob/27c97ca60f580da23af2b06a63231e0373917a64/.pre-commit-hooks.yaml) I realised we could add a `alejandra-system` hook for users who might prefer using their system `alejandra` executable.

The following configuration

```yaml
  - repo: https://github.com/kamadorueda/alejandra
    rev: main
    hooks:
      - id: alejandra-system
```

will now call the system binary while 

```yaml
  - repo: https://github.com/kamadorueda/alejandra
    rev: main
    hooks:
      - id: alejandra
```

still use the Nix build wrapper script.