### PR TITLE
docs: add pre-commit-hooks.nix example

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,16 @@
           - id: alejandra # Requires Nix to be previously installed in the system
           - id: alejandra-system # Requires Alejandra to be previously installed in the system
     ```
+    
+  - [pre-commit-hooks.nix](https://github.com/cachix/pre-commit-hooks.nix)
+  
+    ```nix
+    pre-commit-check = pre-commit-hooks.lib.${system}.run {
+      hooks = {
+        alejandra.enable = true;
+      };
+    };
+    ```
 
 ## Getting started
 


### PR DESCRIPTION
I just discovered [pre-commit-hooks.nix](https://github.com/cachix/pre-commit-hooks.nix) which already supports Alejandra. I thought it was worth mentioning in the documentation.