### PR TITLE
Don't add blank lines after comments in `inherit`

### DIFF
--- a/src/alejandra/src/rules/inherit.rs
+++ b/src/alejandra/src/rules/inherit.rs
@@ -53,7 +53,15 @@ pub(crate) fn rule(
                 steps.push_back(crate::builder::Step::Whitespace);
                 steps.push_back(crate::builder::Step::Comment(text));
                 steps.push_back(crate::builder::Step::NewLine);
-                steps.push_back(crate::builder::Step::Pad);
+                // Only add padding if there are no `trivialities` (that is, there's no extra
+                // `Newlines(_)` to be added) or if the first one is a comment (that is, it'll need
+                // to be indented to match the content).
+                if matches!(
+                    child.trivialities.front(),
+                    None | Some(crate::children2::Trivia::Comment(_))
+                ) {
+                    steps.push_back(crate::builder::Step::Pad);
+                }
             } else if (not_last_child && !child.has_trivialities)
                 || matches!(
                     child.trivialities.front(),
@@ -64,10 +72,20 @@ pub(crate) fn rule(
                 steps.push_back(crate::builder::Step::Pad);
             }
 
-            for trivia in child.trivialities {
+            let mut trivia_iter = child.trivialities.into_iter().peekable();
+            while let Some(trivia) = trivia_iter.next() {
                 match trivia {
                     crate::children2::Trivia::Comment(text) => {
                         steps.push_back(crate::builder::Step::Comment(text));
+                        // If the next `trivia` is a newline, don't add newlines and padding at the
+                        // end of this iteration, as it will lead to a new blank line in the
+                        // output.
+                        if matches!(
+                            trivia_iter.peek(),
+                            Some(crate::children2::Trivia::Newlines(_))
+                        ) {
+                            continue;
+                        }
                     }
                     crate::children2::Trivia::Newlines(_) => {}
                 }

--- a/src/alejandra/tests/cases/inherit/out
+++ b/src/alejandra/tests/cases/inherit/out
@@ -89,11 +89,11 @@
   {
     inherit # test
       a # test
-      
+
       b # test
       c # test
       d # test
-      
+
       e
       f
       g

--- a/src/alejandra/tests/cases/inherit_blank_trailing/in
+++ b/src/alejandra/tests/cases/inherit_blank_trailing/in
@@ -1,0 +1,34 @@
+[
+  {
+    inherit # test
+      a # test
+
+      b # test
+      c # test
+      d # test
+
+      e
+      f
+
+      g
+      h
+      ;
+  }
+  {
+    inherit
+      a # mixed trivialities
+
+      # comment 1
+      # comment 2
+
+      # comment 3 after blanks
+      b # multiple newlines
+
+
+      c # multiple comments
+      # comment 1
+      # comment 2
+      # comment 3
+      ;
+  }
+]

--- a/src/alejandra/tests/cases/inherit_blank_trailing/out
+++ b/src/alejandra/tests/cases/inherit_blank_trailing/out
@@ -1,0 +1,31 @@
+[
+  {
+    inherit # test
+      a # test
+
+      b # test
+      c # test
+      d # test
+
+      e
+      f
+      g
+      h
+      ;
+  }
+  {
+    inherit
+      a # mixed trivialities
+
+      # comment 1
+      # comment 2
+      # comment 3 after blanks
+      b # multiple newlines
+
+      c # multiple comments
+      # comment 1
+      # comment 2
+      # comment 3
+      ;
+  }
+]

--- a/src/alejandra/tests/cases/inherit_comment/in
+++ b/src/alejandra/tests/cases/inherit_comment/in
@@ -1,0 +1,7 @@
+{
+  inherit # eeby deeby
+    a
+    # b
+    c
+    ;
+}

--- a/src/alejandra/tests/cases/inherit_comment/out
+++ b/src/alejandra/tests/cases/inherit_comment/out
@@ -1,0 +1,7 @@
+{
+  inherit # eeby deeby
+    a
+    # b
+    c
+    ;
+}


### PR DESCRIPTION
Fixes #376

Note that handling of extra newlines in `inherit` statements is still a little janky; usually blank lines will be removed from formatted output, but in some cases (e.g. between an end-of-line comment and a full-line comment) they will be preserved. See the tests added for a few examples of this.

It's probably a good idea to take a position on this (I lean towards collapsing multiple consecutive blank lines into one blank line, but otherwise not removing them from the output) and add it to `STYLE.md` at some point, but that's out-of-scope for this PR. (I didn't want to change the way we format the existing test-cases except to remove trailing whitespace.)