### PR TITLE
quote URLs in nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -5,7 +5,7 @@
     fenix.url = "github:nix-community/fenix";
     fenix.inputs.nixpkgs.follows = "nixpkgs";
 
-    flakeCompat.url = github:edolstra/flake-compat;
+    flakeCompat.url = "github:edolstra/flake-compat";
     flakeCompat.flake = false;
 
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable-small";


### PR DESCRIPTION
While the Nix language allows for URL literals, unquoted URLs are being deprecated and their usage is discouraged.

https://nixos.org/manual/nix/stable/contributing/experimental-features.html#xp-feature-no-url-literals
