### PR TITLE
Make tests green on systems with different number of physical CPUs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,6 +21,7 @@ dependencies = [
  "clap",
  "futures",
  "num_cpus",
+ "pretty_assertions",
  "rand",
  "toml",
  "walkdir",

--- a/src/alejandra_cli/Cargo.toml
+++ b/src/alejandra_cli/Cargo.toml
@@ -30,3 +30,6 @@ license = "Unlicense"
 name = "alejandra_cli"
 repository = "https://github.com/kamadorueda/alejandra"
 version = "3.1.0"
+
+[dev-dependencies]
+pretty_assertions = "1.3.0"

--- a/src/alejandra_cli/src/cli.rs
+++ b/src/alejandra_cli/src/cli.rs
@@ -1,3 +1,4 @@
+use std::env;
 use std::fs::read_to_string;
 use std::io::Read;
 
@@ -145,8 +146,15 @@ pub fn main() -> ! {
     let include: Vec<&str> =
         args.include.iter().map(String::as_str).collect::<Vec<&str>>();
 
-    let threads =
-        args.threads.map_or_else(num_cpus::get_physical, Into::<usize>::into);
+    // Try CLI value, then env var, then fall back to number of physical CPUs.
+    let threads: usize = if let Some(cli_threads) = args.threads {
+        cli_threads.into() // convert u8 to usize
+    } else {
+        env::var("ALEJANDRA_THREADS")
+            .ok()
+            .and_then(|v| v.parse::<usize>().ok())
+            .unwrap_or_else(num_cpus::get_physical)
+    };
 
     let verbosity = match args.quiet {
         0 => Verbosity::Everything,

--- a/src/alejandra_cli/tests/cli.rs
+++ b/src/alejandra_cli/tests/cli.rs
@@ -4,6 +4,8 @@ use std::path::PathBuf;
 use std::process::Command;
 use std::process::Stdio;
 
+use pretty_assertions::assert_eq;
+
 #[derive(Debug)]
 struct TestCase {
     args:  &'static [&'static str],
@@ -126,6 +128,7 @@ fn cases() {
         output_got.push_str(&format!("args: {:?}\n", case.args));
 
         let mut child = Command::new("cargo")
+            .env("ALEJANDRA_THREADS", "4")
             .args(["run", "--quiet", "--"])
             .args(case.args)
             .stdin(Stdio::piped())


### PR DESCRIPTION
Done by introducing a ALEJANDRA_THREAD env variable instead of adding e.g. `--threads 4` to all existing test cases and update the entire output.txt file (it shows the cli args used). That was the lowest number of lines to change. The cli now uses the `--threads` value, then env var, then falls back to number of physical CPUs. Any better idea?

Also pretty print the assert_eq call of the big output.txt comparison to be actually able to see where things fail with diff. This allowed me to better detect what the PR is fixing by showing e.g.:
```
<  Checking style in 1 file using 4 threads.
>  Checking style in 1 file using 2 threads.
```