### PR TITLE
fix: preserve trailing whitespace in multiline strings (#409, #442)

### DIFF
--- a/src/alejandra/src/rules/string.rs
+++ b/src/alejandra/src/rules/string.rs
@@ -59,13 +59,15 @@ pub(crate) fn rule(
 
         let lines: Vec<&str> = content.split('\n').collect();
 
-        let should_trim_end: bool =
-            !lines.is_empty() && lines[lines.len() - 1].trim().is_empty();
-
+        // IMPORTANT: Nix preserves trailing whitespace in multiline strings.
+        // We must NOT trim trailing whitespace from content lines — it's semantically significant.
+        // However, trim the last line IF it's whitespace-only (it's just formatting, not content).
         let mut lines: Vec<String> = lines
             .iter()
-            .map(|line| {
-                if should_trim_end {
+            .enumerate()
+            .map(|(i, line)| {
+                // Only trim the very last line if it's whitespace-only
+                if i == lines.len() - 1 && line.trim().is_empty() {
                     line.trim_end().to_string()
                 } else {
                     line.to_string()

--- a/src/alejandra/tests/cases/default/string_semantic/in.nix
+++ b/src/alejandra/tests/cases/default/string_semantic/in.nix
@@ -1,0 +1,30 @@
+{
+  # Issue #409: Trailing whitespace in multiline strings
+  # These lines have actual trailing spaces that must be preserved
+  trailing_spaces = ''
+    line without trailing
+    line with two spaces  
+    another line
+  '';
+
+  # Issue #442: String escape preservation
+  # These escape sequences must not be modified
+  escapes = ''
+    ''${variable}
+    '''
+    ''''
+  '';
+
+  # Indentation significance
+  # When indentation is part of the content (like Makefiles)
+  makefile = ''
+    target: deps
+    	echo "built"
+  '';
+
+  # Mixed: escapes with interpolation
+  complex = ''
+    prefix ''${expr} suffix
+    ''${func "arg"}
+  '';
+}

--- a/src/alejandra/tests/cases/default/string_semantic/out.nix
+++ b/src/alejandra/tests/cases/default/string_semantic/out.nix
@@ -1,0 +1,30 @@
+{
+  # Issue #409: Trailing whitespace in multiline strings
+  # These lines have actual trailing spaces that must be preserved
+  trailing_spaces = ''
+    line without trailing
+    line with two spaces  
+    another line
+  '';
+
+  # Issue #442: String escape preservation
+  # These escape sequences must not be modified
+  escapes = ''
+    ''${variable}
+    '''
+    ''''
+  '';
+
+  # Indentation significance
+  # When indentation is part of the content (like Makefiles)
+  makefile = ''
+    target: deps
+    	echo "built"
+  '';
+
+  # Mixed: escapes with interpolation
+  complex = ''
+    prefix ''${expr} suffix
+    ''${func "arg"}
+  '';
+}

--- a/src/alejandra/tests/cases/default/string_trailing_spaces/in.nix
+++ b/src/alejandra/tests/cases/default/string_trailing_spaces/in.nix
@@ -1,0 +1,24 @@
+# Test case for issue #409: trailing whitespace preservation
+# Content lines have actual trailing spaces that must NOT be stripped
+{
+  # Case 1: trailing spaces on content lines
+  example = ''
+    no trailing
+    has two trailing spaces  
+    another with spaces  
+  '';
+
+  # Case 2: Makefile-like content where trailing spaces might be significant
+  makefile_like = ''
+    target: deps
+    	echo "hello"  
+  '';
+
+  # Case 3: mixed trailing patterns
+  mixed = ''
+    clean line
+    trailing here  
+    another clean
+    ends with space 
+  '';
+}

--- a/src/alejandra/tests/cases/default/string_trailing_spaces/out.nix
+++ b/src/alejandra/tests/cases/default/string_trailing_spaces/out.nix
@@ -1,0 +1,24 @@
+# Test case for issue #409: trailing whitespace preservation
+# Content lines have actual trailing spaces that must NOT be stripped
+{
+  # Case 1: trailing spaces on content lines
+  example = ''
+    no trailing
+    has two trailing spaces  
+    another with spaces  
+  '';
+
+  # Case 2: Makefile-like content where trailing spaces might be significant
+  makefile_like = ''
+    target: deps
+    	echo "hello"  
+  '';
+
+  # Case 3: mixed trailing patterns
+  mixed = ''
+    clean line
+    trailing here  
+    another clean
+    ends with space 
+  '';
+}

--- a/src/alejandra/tests/cases/indentation-four-spaces/string_semantic/in.nix
+++ b/src/alejandra/tests/cases/indentation-four-spaces/string_semantic/in.nix
@@ -1,0 +1,30 @@
+{
+  # Issue #409: Trailing whitespace in multiline strings
+  # These lines have actual trailing spaces that must be preserved
+  trailing_spaces = ''
+    line without trailing
+    line with two spaces  
+    another line
+  '';
+
+  # Issue #442: String escape preservation
+  # These escape sequences must not be modified
+  escapes = ''
+    ''${variable}
+    '''
+    ''''
+  '';
+
+  # Indentation significance
+  # When indentation is part of the content (like Makefiles)
+  makefile = ''
+    target: deps
+    	echo "built"
+  '';
+
+  # Mixed: escapes with interpolation
+  complex = ''
+    prefix ''${expr} suffix
+    ''${func "arg"}
+  '';
+}

--- a/src/alejandra/tests/cases/indentation-four-spaces/string_semantic/out.nix
+++ b/src/alejandra/tests/cases/indentation-four-spaces/string_semantic/out.nix
@@ -1,0 +1,30 @@
+{
+    # Issue #409: Trailing whitespace in multiline strings
+    # These lines have actual trailing spaces that must be preserved
+    trailing_spaces = ''
+        line without trailing
+        line with two spaces  
+        another line
+    '';
+
+    # Issue #442: String escape preservation
+    # These escape sequences must not be modified
+    escapes = ''
+        ''${variable}
+        '''
+        ''''
+    '';
+
+    # Indentation significance
+    # When indentation is part of the content (like Makefiles)
+    makefile = ''
+        target: deps
+        	echo "built"
+    '';
+
+    # Mixed: escapes with interpolation
+    complex = ''
+        prefix ''${expr} suffix
+        ''${func "arg"}
+    '';
+}

--- a/src/alejandra/tests/cases/indentation-four-spaces/string_trailing_spaces/in.nix
+++ b/src/alejandra/tests/cases/indentation-four-spaces/string_trailing_spaces/in.nix
@@ -1,0 +1,24 @@
+# Test case for issue #409: trailing whitespace preservation
+# Content lines have actual trailing spaces that must NOT be stripped
+{
+  # Case 1: trailing spaces on content lines
+  example = ''
+    no trailing
+    has two trailing spaces  
+    another with spaces  
+  '';
+
+  # Case 2: Makefile-like content where trailing spaces might be significant
+  makefile_like = ''
+    target: deps
+    	echo "hello"  
+  '';
+
+  # Case 3: mixed trailing patterns
+  mixed = ''
+    clean line
+    trailing here  
+    another clean
+    ends with space 
+  '';
+}

--- a/src/alejandra/tests/cases/indentation-four-spaces/string_trailing_spaces/out.nix
+++ b/src/alejandra/tests/cases/indentation-four-spaces/string_trailing_spaces/out.nix
@@ -1,0 +1,24 @@
+# Test case for issue #409: trailing whitespace preservation
+# Content lines have actual trailing spaces that must NOT be stripped
+{
+    # Case 1: trailing spaces on content lines
+    example = ''
+        no trailing
+        has two trailing spaces  
+        another with spaces  
+    '';
+
+    # Case 2: Makefile-like content where trailing spaces might be significant
+    makefile_like = ''
+        target: deps
+        	echo "hello"  
+    '';
+
+    # Case 3: mixed trailing patterns
+    mixed = ''
+        clean line
+        trailing here  
+        another clean
+        ends with space 
+    '';
+}

--- a/src/alejandra/tests/cases/indentation-tabs/string_semantic/in.nix
+++ b/src/alejandra/tests/cases/indentation-tabs/string_semantic/in.nix
@@ -1,0 +1,30 @@
+{
+  # Issue #409: Trailing whitespace in multiline strings
+  # These lines have actual trailing spaces that must be preserved
+  trailing_spaces = ''
+    line without trailing
+    line with two spaces  
+    another line
+  '';
+
+  # Issue #442: String escape preservation
+  # These escape sequences must not be modified
+  escapes = ''
+    ''${variable}
+    '''
+    ''''
+  '';
+
+  # Indentation significance
+  # When indentation is part of the content (like Makefiles)
+  makefile = ''
+    target: deps
+    	echo "built"
+  '';
+
+  # Mixed: escapes with interpolation
+  complex = ''
+    prefix ''${expr} suffix
+    ''${func "arg"}
+  '';
+}

--- a/src/alejandra/tests/cases/indentation-tabs/string_semantic/out.nix
+++ b/src/alejandra/tests/cases/indentation-tabs/string_semantic/out.nix
@@ -1,0 +1,30 @@
+{
+	# Issue #409: Trailing whitespace in multiline strings
+	# These lines have actual trailing spaces that must be preserved
+	trailing_spaces = ''
+    line without trailing
+    line with two spaces  
+    another line
+  '';
+
+	# Issue #442: String escape preservation
+	# These escape sequences must not be modified
+	escapes = ''
+    ''${variable}
+    '''
+    ''''
+  '';
+
+	# Indentation significance
+	# When indentation is part of the content (like Makefiles)
+	makefile = ''
+    target: deps
+    	echo "built"
+  '';
+
+	# Mixed: escapes with interpolation
+	complex = ''
+    prefix ''${expr} suffix
+    ''${func "arg"}
+  '';
+}

--- a/src/alejandra/tests/cases/indentation-tabs/string_trailing_spaces/in.nix
+++ b/src/alejandra/tests/cases/indentation-tabs/string_trailing_spaces/in.nix
@@ -1,0 +1,24 @@
+# Test case for issue #409: trailing whitespace preservation
+# Content lines have actual trailing spaces that must NOT be stripped
+{
+  # Case 1: trailing spaces on content lines
+  example = ''
+    no trailing
+    has two trailing spaces  
+    another with spaces  
+  '';
+
+  # Case 2: Makefile-like content where trailing spaces might be significant
+  makefile_like = ''
+    target: deps
+    	echo "hello"  
+  '';
+
+  # Case 3: mixed trailing patterns
+  mixed = ''
+    clean line
+    trailing here  
+    another clean
+    ends with space 
+  '';
+}

--- a/src/alejandra/tests/cases/indentation-tabs/string_trailing_spaces/out.nix
+++ b/src/alejandra/tests/cases/indentation-tabs/string_trailing_spaces/out.nix
@@ -1,0 +1,24 @@
+# Test case for issue #409: trailing whitespace preservation
+# Content lines have actual trailing spaces that must NOT be stripped
+{
+	# Case 1: trailing spaces on content lines
+	example = ''
+    no trailing
+    has two trailing spaces  
+    another with spaces  
+  '';
+
+	# Case 2: Makefile-like content where trailing spaces might be significant
+	makefile_like = ''
+    target: deps
+    	echo "hello"  
+  '';
+
+	# Case 3: mixed trailing patterns
+	mixed = ''
+    clean line
+    trailing here  
+    another clean
+    ends with space 
+  '';
+}


### PR DESCRIPTION
The formatter was incorrectly stripping trailing whitespace from all lines when the last line was whitespace-only. This corrupted the semantic content of strings, especially for Makefiles and other content where indentation and trailing spaces are significant.

Changes:
- Remove overly broad trim logic that affected all lines
- Only trim the final whitespace-only line (formatting, not content)
- Preserve trailing spaces on content lines (semantically significant)
- Maintain proper closing '' indentation

Added regression tests:
- string_semantic: comprehensive tests for #409 and #442
- string_trailing_spaces: specific test for trailing whitespace preservation

All tests pass with no regressions.