### PR TITLE
test: Enhance string_semantic with comprehensive issue #442 test cases

### DIFF
--- a/src/alejandra/tests/cases/default/string_semantic/in.nix
+++ b/src/alejandra/tests/cases/default/string_semantic/in.nix
@@ -7,10 +7,12 @@
     another line
   '';
 
-  # Issue #442: String escape preservation
-  # These escape sequences must not be modified
+  # Issue #442: String escape sequences must be preserved
+  # Escapes like ''${...} prevent interpolation and should not be modified
   escapes = ''
+    ''${1+x}
     ''${variable}
+    ''${foo.bar}
     '''
     ''''
   '';
@@ -22,9 +24,10 @@
     	echo "built"
   '';
 
-  # Mixed: escapes with interpolation
+  # Mixed: escapes with interpolation and trailing spaces
   complex = ''
-    prefix ''${expr} suffix
+    prefix ''${expr} suffix  
     ''${func "arg"}
+    escaped: '''and then '''${real_interp}
   '';
 }

--- a/src/alejandra/tests/cases/default/string_semantic/out.nix
+++ b/src/alejandra/tests/cases/default/string_semantic/out.nix
@@ -7,10 +7,12 @@
     another line
   '';
 
-  # Issue #442: String escape preservation
-  # These escape sequences must not be modified
+  # Issue #442: String escape sequences must be preserved
+  # Escapes like ''${...} prevent interpolation and should not be modified
   escapes = ''
+    ''${1+x}
     ''${variable}
+    ''${foo.bar}
     '''
     ''''
   '';
@@ -22,9 +24,10 @@
     	echo "built"
   '';
 
-  # Mixed: escapes with interpolation
+  # Mixed: escapes with interpolation and trailing spaces
   complex = ''
-    prefix ''${expr} suffix
+    prefix ''${expr} suffix  
     ''${func "arg"}
+    escaped: '''and then '''${real_interp}
   '';
 }

--- a/src/alejandra/tests/cases/indentation-four-spaces/string_semantic/in.nix
+++ b/src/alejandra/tests/cases/indentation-four-spaces/string_semantic/in.nix
@@ -7,10 +7,12 @@
     another line
   '';
 
-  # Issue #442: String escape preservation
-  # These escape sequences must not be modified
+  # Issue #442: String escape sequences must be preserved
+  # Escapes like ''${...} prevent interpolation and should not be modified
   escapes = ''
+    ''${1+x}
     ''${variable}
+    ''${foo.bar}
     '''
     ''''
   '';
@@ -22,9 +24,10 @@
     	echo "built"
   '';
 
-  # Mixed: escapes with interpolation
+  # Mixed: escapes with interpolation and trailing spaces
   complex = ''
-    prefix ''${expr} suffix
+    prefix ''${expr} suffix  
     ''${func "arg"}
+    escaped: '''and then '''${real_interp}
   '';
 }

--- a/src/alejandra/tests/cases/indentation-four-spaces/string_semantic/out.nix
+++ b/src/alejandra/tests/cases/indentation-four-spaces/string_semantic/out.nix
@@ -7,10 +7,12 @@
         another line
     '';
 
-    # Issue #442: String escape preservation
-    # These escape sequences must not be modified
+    # Issue #442: String escape sequences must be preserved
+    # Escapes like ''${...} prevent interpolation and should not be modified
     escapes = ''
+        ''${1+x}
         ''${variable}
+        ''${foo.bar}
         '''
         ''''
     '';
@@ -22,9 +24,10 @@
         	echo "built"
     '';
 
-    # Mixed: escapes with interpolation
+    # Mixed: escapes with interpolation and trailing spaces
     complex = ''
-        prefix ''${expr} suffix
+        prefix ''${expr} suffix  
         ''${func "arg"}
+        escaped: '''and then '''${real_interp}
     '';
 }

--- a/src/alejandra/tests/cases/indentation-tabs/string_semantic/in.nix
+++ b/src/alejandra/tests/cases/indentation-tabs/string_semantic/in.nix
@@ -7,10 +7,12 @@
     another line
   '';
 
-  # Issue #442: String escape preservation
-  # These escape sequences must not be modified
+  # Issue #442: String escape sequences must be preserved
+  # Escapes like ''${...} prevent interpolation and should not be modified
   escapes = ''
+    ''${1+x}
     ''${variable}
+    ''${foo.bar}
     '''
     ''''
   '';
@@ -22,9 +24,10 @@
     	echo "built"
   '';
 
-  # Mixed: escapes with interpolation
+  # Mixed: escapes with interpolation and trailing spaces
   complex = ''
-    prefix ''${expr} suffix
+    prefix ''${expr} suffix  
     ''${func "arg"}
+    escaped: '''and then '''${real_interp}
   '';
 }

--- a/src/alejandra/tests/cases/indentation-tabs/string_semantic/out.nix
+++ b/src/alejandra/tests/cases/indentation-tabs/string_semantic/out.nix
@@ -7,10 +7,12 @@
     another line
   '';
 
-	# Issue #442: String escape preservation
-	# These escape sequences must not be modified
+	# Issue #442: String escape sequences must be preserved
+	# Escapes like ''${...} prevent interpolation and should not be modified
 	escapes = ''
+    ''${1+x}
     ''${variable}
+    ''${foo.bar}
     '''
     ''''
   '';
@@ -22,9 +24,10 @@
     	echo "built"
   '';
 
-	# Mixed: escapes with interpolation
+	# Mixed: escapes with interpolation and trailing spaces
 	complex = ''
-    prefix ''${expr} suffix
+    prefix ''${expr} suffix  
     ''${func "arg"}
+    escaped: '''and then '''${real_interp}
   '';
 }


### PR DESCRIPTION
Add more thorough test coverage for issue #442 (string escape sequences):
- Include the specific ''${1+x} case mentioned in the issue
- Add ''${foo.bar} for nested property escapes
- Add mixed cases with both escapes and real interpolations
- Ensure escapes with trailing spaces are tested

Verification confirms all escape sequences are preserved:
- ''${1+x}, ''${variable}, ''${foo.bar} ✓
- ''', '''' (quote escapes) ✓
- Mixed escapes and interpolations ✓
- Escapes with trailing whitespace ✓

Both issues #409 and #442 now have comprehensive regression tests.